### PR TITLE
Updated engine recommendation in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "webpack": "^4.31.0",
     "webpack-cli": "^3.3.2"
   },
-  "engines": {},
+  "engines": {
+    "node": ">=16 <17"
+  },
   "scripts": {
     "webpack": "webpack",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Just a simple update so there is a warning to use a node version somewhere in the 16 range.  I started by using `18.12.1` and that generated an error related to the crypto package's Hash class.

I did some quick testing to see what node version it would go down to but I only found versions in the 16 range would work. Tested from `16.0.0` to `16.19.0` and confirmed it was working.