### PR TITLE
build: pin package manager and disable automatic install-time lifecycle scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableScripts: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "k6-es6",
   "version": "1.0.0",
+  "packageManager": "npm@10.9.2",
   "description": "test project for k6 to use es6 through the power of babel and webpack",
   "devDependencies": {
     "@babel/core": "^7.23.7",


### PR DESCRIPTION
Disables automatic execution of npm/yarn install-time lifecycle scripts (`preinstall`, `install`, `postinstall`, `prepare`, ...) so a malicious or compromised transitive dependency cannot run arbitrary code during `npm install` / `yarn install`. Manually invoked scripts (`npm run ...`, `yarn ...`) are unaffected — only auto-execution at install time is blocked.

Writes all three package-manager config files at the repo root, regardless of which manager the repo currently uses. Defense in depth: each file is read only by its own tool, so writing all three costs nothing and guards against npm, Yarn Classic, and Yarn Berry equally.
- `.npmrc` → `ignore-scripts=true` (npm, also honored by Yarn Classic)
- `.yarnrc` → `ignore-scripts true` (Yarn Classic, explicit)
- `.yarnrc.yml` → `enableScripts: false` (Yarn Berry; does not read `.npmrc`)

Pins the package manager via `packageManager` in `package.json` so Corepack uses a known version.